### PR TITLE
design: 커뮤니티, 공지사항 텍스트 색상 수정 #69

### DIFF
--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -691,6 +691,7 @@ footer {
 .detail-content p {
   margin: 0;
   min-height: 1em;
+  color: var(--text);
 }
 
 .detail-actions {


### PR DESCRIPTION
커뮤니티, 공지사항에서 텍스트가 흰색으로 나오는 오류 수정했습니다.
Resolves: #69 

<img width="873" height="606" alt="image" src="https://github.com/user-attachments/assets/75d11af0-1665-40a9-ae5e-9b317a07a4de" />

